### PR TITLE
Mamba install

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,8 @@
 # https://hub.docker.com/_/microsoft-vscode-devcontainers
 FROM mcr.microsoft.com/vscode/devcontainers/miniconda:0-3
 
-RUN conda install -c conda-forge fenics
+RUN conda install -c conda-forge mamba
+RUN mamba install -c conda-forge fenics
 
 # Possible when FESTIM is open-source 
 # RUN pip install FESTIM==0.10.0


### PR DESCRIPTION
Until https://github.com/conda-forge/fenics-feedstock/issues/162 is fixed, this workaround can be used to install fenics